### PR TITLE
Add | (or) operator

### DIFF
--- a/src/jrep.c
+++ b/src/jrep.c
@@ -136,6 +136,7 @@ int main(int argc, char *argv[]) {
   matches = false;
   for (int j = 0; j < orcount+1; ++j) {
    matches |= inverse ^ does_match(line, &state[j], only, &buffer);
+   if (!only && matches) break;
   }
   if (matches) {
    ++c;

--- a/src/jrep.c
+++ b/src/jrep.c
@@ -96,18 +96,22 @@ int main(int argc, char *argv[]) {
  bool matches = false;
 
  /* This struct stores every state in the graph */
- struct s_state state;
+ int regex_count = 1;
+ struct s_state *state = malloc(regex_count * sizeof *state);
 
  /* Parse the expression or throw an error */
- if (parse(argv[pattern], &state) < 0) {
+ if (parse(argv[pattern], &state[0]) < 0) {
   return 2;
  }
 
  /* Check for matches in each line of the file */
  while (bytes_read > 0) {
   ++lc;
-  if (inverse ^ does_match(line, &state, only, &buffer)) {
-   matches = true;
+  matches = false;
+  for (int j = 0; j < regex_count; ++j) {
+   matches |= inverse ^ does_match(line, &state[0], only, &buffer);
+  }
+  if (matches) {
    ++c;
    if (!count) {
     if (print_names) printf("%s:", fn);


### PR DESCRIPTION
The idea behind this is that by saying "or," what you really mean is that the line could match multiple patterns. jrep 'a|b|c' means we want to check whether the input matches any of those three patterns. So instead convoluting the state graph, we loop through an array of graphs until one matches.

Note that the -o option doesn't work properly with or statements yet, but it also doesn't work with multiple matches on a line, so that option needs to be reworked anyway.
